### PR TITLE
add reference to Docker repo naming conventions

### DIFF
--- a/docs/get-involved/developing-repositories.md
+++ b/docs/get-involved/developing-repositories.md
@@ -18,7 +18,7 @@ To make it easy to create a repository with all the necessary bibs and bobs, I'v
 
 Before you go any further, it's a good idea to think about what your new repository will be called. In general, I've named repositories after GLAM collections. In the instructions below you'll be asked for:
 
-* a GitHub repository name – all lower case, with hyphens instead of spaces, eg: 'trove-newspapers'
+* a GitHub repository name – all lowercase or numeric, with hyphens or underscores instead of spaces (a requirement for [Docker](https://docs.docker.com/docker-hub/repos/#creating-repositories)), eg: 'trove-newspapers'
 * a project name – the human-friendly version, used in headings, eg: 'Trove newspapers'
 
 ### Create the repository


### PR DESCRIPTION
This is to help understand the context of these requirements, since it isn't a GitHub requirement. If not followed, a GitHub workbench may be "created" from the template without the Docker commands working. This section of the workbench docs needs to be linked to from the template as well.